### PR TITLE
default domain for LinkCreate

### DIFF
--- a/src/resources/links/info.ts
+++ b/src/resources/links/info.ts
@@ -18,8 +18,8 @@ export class Info extends APIResource {
 
 export interface InfoRetrieveParams {
   /**
-   * The domain of the link to retrieve. E.g. for spt.fi/github, the domain is
-   * 'dub.sh'. If not provided the default domain is 'dub.sh'.
+   * The domain of the link to retrieve. E.g. for spt.fi/favsong, the domain is
+   * 'spt.fi'. If not provided the default domain is 'dub.sh'.
    */
   domain?: string;
 

--- a/src/resources/links/info.ts
+++ b/src/resources/links/info.ts
@@ -10,6 +10,7 @@ export class Info extends APIResource {
    * Retrieve the info for a link from their domain and key.
    */
   retrieve(params: InfoRetrieveParams, options?: Core.RequestOptions): Core.APIPromise<Shared.Link> {
+    params.domain = params.domain || 'dub.sh';
     const { projectSlug = this._client.projectSlug, ...query } = params;
     return this._client.get('/links/info', { query: { projectSlug, ...query }, ...options });
   }
@@ -17,10 +18,10 @@ export class Info extends APIResource {
 
 export interface InfoRetrieveParams {
   /**
-   * The domain of the link to retrieve. E.g. for dub.sh/github, the domain is
-   * 'dub.sh'.
+   * The domain of the link to retrieve. E.g. for spt.fi/github, the domain is
+   * 'dub.sh'. If not provided the default domain is 'dub.sh'.
    */
-  domain: string;
+  domain?: string;
 
   /**
    * The key of the link to retrieve. E.g. for dub.sh/github, the key is 'github'.

--- a/src/resources/links/links.ts
+++ b/src/resources/links/links.ts
@@ -16,7 +16,6 @@ export class Links extends APIResource {
    */
   create(params: LinkCreateParams, options?: Core.RequestOptions): Core.APIPromise<Shared.Link> {
     params.domain = params.domain || 'dub.sh';
-    console.log('Params:', params);
     const { projectSlug = this._client.projectSlug, ...body } = params;
     return this._client.post('/links', { query: { projectSlug }, body, ...options });
   }
@@ -65,8 +64,8 @@ export interface LinkCreateParams {
   projectSlug?: string;
 
   /**
-   * Body param: The domain of the short link. If not set it will default to
-   * 'dub.sh'.
+   * Body param: The domain of the short link. If not provided, the default domain
+   * is 'dub.sh'.
    */
   domain?: string;
 

--- a/src/resources/links/links.ts
+++ b/src/resources/links/links.ts
@@ -15,6 +15,8 @@ export class Links extends APIResource {
    * Create a new link for the authenticated project.
    */
   create(params: LinkCreateParams, options?: Core.RequestOptions): Core.APIPromise<Shared.Link> {
+    params.domain = params.domain || 'dub.sh';
+    console.log('Params:', params);
     const { projectSlug = this._client.projectSlug, ...body } = params;
     return this._client.post('/links', { query: { projectSlug }, body, ...options });
   }
@@ -63,9 +65,10 @@ export interface LinkCreateParams {
   projectSlug?: string;
 
   /**
-   * Body param: The domain of the short link.
+   * Body param: The domain of the short link. If not set it will default to
+   * 'dub.sh'.
    */
-  domain: string;
+  domain?: string;
 
   /**
    * Body param: The destination URL of the short link.


### PR DESCRIPTION
## Set default domain for LinkCreate
This sets `dub.sh` as the default domain if none is set, this is the alternative solution to https://github.com/dubinc/dub-node/pull/21 which makes the current read me valid.

This allows for
```js
import Dub from 'dub';

const dub = new Dub({
  token: process.env['DUB_API_KEY'], // This is the default and can be omitted
  projectSlug: 'dub_project_slug',
});

async function main() {
  const link = await dub.links.create({ url: 'google.com' });

  console.log(link);
}

main();
```

Where as despite the documentation it currently requires

```js
const link = await dub.links.create({ url: 'google.com', domain: 'google.com' });
```