### PR TITLE
fix: re-add default SDK export

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,1 @@
+src/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from "./sdk";
 export * from "./lib/config";
 
 import { Dub } from './sdk'
-// eslint-disable-next-line import/no-default-export
-export default Dub;
+
+/** @deprecated Use named export instead: `import { Dub } from "dub";` */
+export default Dub; // eslint-disable-line import/no-default-export

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,7 @@
 
 export * from "./sdk";
 export * from "./lib/config";
+
+import { Dub } from './sdk'
+// eslint-disable-next-line import/no-default-export
+export default Dub;


### PR DESCRIPTION
This change re-instates the default export that was in the previous versions of the SDK.