### PR TITLE
Return the error as standard response object

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -21,7 +21,7 @@ typescript:
     peerDependencies: {}
   additionalPackageJSON: {}
   author: Dub
-  clientServerStatusCodesAsErrors: true
+  clientServerStatusCodesAsErrors: false
   enumFormat: union
   flattenGlobalSecurity: true
   imports:


### PR DESCRIPTION
Rather than throwing the error, return the error as standard response object.

```
const result = await dub.links.create({ url, key, domain });

if(result.error) {
 // Handle the error
}
```