### PR TITLE
fix: infer optional arguments in SDK methods

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,26 +3,31 @@ id: f28179cc-ef59-426d-9e85-60cec22fc642
 management:
   docChecksum: c38ab49043c57320aee33ca443a1c66b
   docVersion: 0.0.1
-  speakeasyVersion: 1.279.0
-  generationVersion: 2.322.5
-  releaseVersion: 0.26.1
-  configChecksum: 2bd291f2df61e20c2670d16d58227cef
+  speakeasyVersion: 1.282.0
+  generationVersion: 2.326.0
+  releaseVersion: 0.27.0
+  configChecksum: 3511857bf47eb65f185cfb3f2c6b5763
   repoURL: https://github.com/dubinc/dub-node.git
   installationURL: https://github.com/dubinc/dub-node
   published: true
 features:
   typescript:
+    additionalDependencies: 0.1.0
     constsAndDefaults: 0.1.5
     core: 3.9.3
     deprecations: 2.81.1
     examples: 2.81.3
     flattening: 2.81.1
     globalSecurity: 2.82.9
+    globalSecurityCallbacks: 0.1.0
+    globalSecurityFlattening: 0.1.0
     globalServerURLs: 2.82.4
     globals: 2.82.1
     hiddenGlobals: 0.1.0
     nameOverrides: 2.81.2
+    nullables: 0.1.0
     responseFormat: 0.2.3
+    sdkHooks: 0.1.0
     unions: 2.85.4
 generatedFiles:
   - src/sdk/links.ts

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,6 +34,7 @@ typescript:
       webhooks: models/webhooks
   inputModelSuffix: input
   maxMethodParams: 0
+  methodArguments: infer-optional-args
   outputModelSuffix: output
   packageName: dub
   responseFormat: flat

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 typescript:
-  version: 0.26.1
+  version: 0.27.0
   additionalDependencies:
     dependencies: {}
     devDependencies:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,18 +1,18 @@
-speakeasyVersion: 1.279.0
+speakeasyVersion: 1.282.0
 sources:
     my-first-source:
         sourceNamespace: my-first-source
-        sourceRevisionDigest: sha256:e6203c2aa1c988a36a86dc96eb739e41e9a39ccf4ed817206a1fff5eb1199a28
-        sourceBlobDigest: sha256:0d376a9762a91f0109b087d69e9516f3bbe68ff02d2ac52483373544e6ab7508
+        sourceRevisionDigest: sha256:93e125426c46395b4a2233b93538de3ab5f87b576187f1b61252288deb289a1f
+        sourceBlobDigest: sha256:6f94ba6f5cc47943b6eb8754892c4ce750e1ea1b9370923312f1f040ffddf040
         tags:
             - latest
 targets:
     my-first-target:
         source: my-first-source
         sourceNamespace: my-first-source
-        sourceRevisionDigest: sha256:e6203c2aa1c988a36a86dc96eb739e41e9a39ccf4ed817206a1fff5eb1199a28
-        sourceBlobDigest: sha256:0d376a9762a91f0109b087d69e9516f3bbe68ff02d2ac52483373544e6ab7508
-        outLocation: /github/workspace/repo
+        sourceRevisionDigest: sha256:93e125426c46395b4a2233b93538de3ab5f87b576187f1b61252288deb289a1f
+        sourceBlobDigest: sha256:6f94ba6f5cc47943b6eb8754892c4ce750e1ea1b9370923312f1f040ffddf040
+        outLocation: /home/disintegrator/github.com/disintegrator/dub-node
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/codeSamples.yaml
+++ b/codeSamples.yaml
@@ -3,88 +3,11 @@ info:
   title: CodeSamples overlay for typescript target
   version: 0.0.0
 actions:
-  - target: $["paths"]["/tags"]["post"]
+  - target: $["paths"]["/links"]["get"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "createTag"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.create({
-                tag: "<value>",
-              });
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/domains/{slug}/transfer"]["post"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "transferDomain"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const slug = \"acme.com\";\n  const requestBody = {\n    newWorkspaceId: \"<value>\",\n  };\n  \n  const result = await dub.transfer(slug, requestBody);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
-  - target: $["paths"]["/domains/{slug}"]["patch"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "updateDomain"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const slug = \"acme.com\";\n  const requestBody = {};\n  \n  const result = await dub.update(slug, requestBody);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
-  - target: $["paths"]["/analytics/city"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getCityAnalytics"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.cities({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/analytics/top_links"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getTopLinks"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.topLinks({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/domains"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "listDomains"
+          "label": "getLinks"
           "source": |-
             import { Dub } from "dub";
 
@@ -101,62 +24,6 @@ actions:
             }
 
             run();
-  - target: $["paths"]["/domains"]["post"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "addDomain"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.add({
-                slug: "acme.com",
-              });
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/domains/{slug}/primary"]["post"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "setPrimaryDomain"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const slug = \"acme.com\";\n  \n  const result = await dub.setPrimary(slug);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
-  - target: $["paths"]["/analytics/timeseries"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getTimeseriesAnalytics"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.timeseries({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/links/{linkId}"]["patch"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "updateLink"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const linkId = \"<value>\";\n  const requestBody = {\n    url: \"https://google/com\",\n  };\n  \n  const result = await dub.update(linkId, requestBody);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
   - target: $["paths"]["/links/bulk"]["post"]
     update:
       "x-codeSamples":
@@ -176,27 +43,6 @@ actions:
                   url: "https://google/com",
                 },
               ]);
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/qr"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getQRCode"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.get({});
 
               // Handle the result
               console.log(result)
@@ -226,17 +72,11 @@ actions:
             }
 
             run();
-  - target: $["paths"]["/links/{linkId}"]["delete"]
+  - target: $["paths"]["/domains/{slug}"]["patch"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "deleteLink"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const linkId = \"<value>\";\n  \n  const result = await dub.delete(linkId);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
-  - target: $["paths"]["/links/count"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getLinksCount"
+          "label": "updateDomain"
           "source": |-
             import { Dub } from "dub";
 
@@ -246,18 +86,18 @@ actions:
             });
 
             async function run() {
-              const result = await dub.count({});
+              const result = await dub.update("acme.com", {});
 
               // Handle the result
               console.log(result)
             }
 
             run();
-  - target: $["paths"]["/links/info"]["get"]
+  - target: $["paths"]["/qr"]["get"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "getLinkInfo"
+          "label": "getQRCode"
           "source": |-
             import { Dub } from "dub";
 
@@ -274,11 +114,11 @@ actions:
             }
 
             run();
-  - target: $["paths"]["/analytics/country"]["get"]
+  - target: $["paths"]["/tags"]["get"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "getCountryAnalytics"
+          "label": "getTags"
           "source": |-
             import { Dub } from "dub";
 
@@ -288,18 +128,18 @@ actions:
             });
 
             async function run() {
-              const result = await dub.countries({});
+              const result = await dub.list({});
 
               // Handle the result
               console.log(result)
             }
 
             run();
-  - target: $["paths"]["/analytics/device"]["get"]
+  - target: $["paths"]["/domains/{slug}"]["delete"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "getDeviceAnalytics"
+          "label": "deleteDomain"
           "source": |-
             import { Dub } from "dub";
 
@@ -309,18 +149,18 @@ actions:
             });
 
             async function run() {
-              const result = await dub.devices({});
+              const result = await dub.delete("acme.com");
 
               // Handle the result
               console.log(result)
             }
 
             run();
-  - target: $["paths"]["/workspaces"]["get"]
+  - target: $["paths"]["/analytics/top_urls"]["get"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "getWorkspaces"
+          "label": "getTopURLs"
           "source": |-
             import { Dub } from "dub";
 
@@ -330,31 +170,7 @@ actions:
             });
 
             async function run() {
-              const result = await dub.list();
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/workspaces"]["post"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "createWorkspace"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.create({
-                name: "<value>",
-                slug: "<value>",
-              });
+              const result = await dub.topUrls({});
 
               // Handle the result
               console.log(result)
@@ -384,69 +200,6 @@ actions:
             }
 
             run();
-  - target: $["paths"]["/links"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getLinks"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.list({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/analytics/referer"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getRefererAnalytics"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.referers({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/tags"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getTags"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.list({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
   - target: $["paths"]["/analytics/browser"]["get"]
     update:
       "x-codeSamples":
@@ -462,48 +215,6 @@ actions:
 
             async function run() {
               const result = await dub.browsers({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/analytics/top_urls"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getTopURLs"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.topUrls({});
-
-              // Handle the result
-              console.log(result)
-            }
-
-            run();
-  - target: $["paths"]["/analytics/clicks"]["get"]
-    update:
-      "x-codeSamples":
-        - "lang": "typescript"
-          "label": "getClicksAnalytics"
-          "source": |-
-            import { Dub } from "dub";
-
-            const dub = new Dub({
-              token: "DUB_API_KEY",
-              workspaceId: "<value>",
-            });
-
-            async function run() {
-              const result = await dub.clicks({});
 
               // Handle the result
               console.log(result)
@@ -531,12 +242,138 @@ actions:
             }
 
             run();
-  - target: $["paths"]["/domains/{slug}"]["delete"]
+  - target: $["paths"]["/domains"]["get"]
     update:
       "x-codeSamples":
         - "lang": "typescript"
-          "label": "deleteDomain"
-          "source": "import { Dub } from \"dub\";\n\nconst dub = new Dub({\n  token: \"DUB_API_KEY\",\n  workspaceId: \"<value>\",\n});\n\nasync function run() {\n  const slug = \"acme.com\";\n  \n  const result = await dub.delete(slug);\n\n  // Handle the result\n  console.log(result)\n}\n\nrun();"
+          "label": "listDomains"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.list({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/domains/{slug}/transfer"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "transferDomain"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.transfer("acme.com", {
+                newWorkspaceId: "<value>",
+              });
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/links/info"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getLinkInfo"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.get({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/links/{linkId}"]["patch"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "updateLink"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.update("<value>", {
+                url: "https://google/com",
+              });
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/referer"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getRefererAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.referers({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/domains"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "addDomain"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.add({
+                slug: "acme.com",
+              });
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
   - target: $["paths"]["/links"]["post"]
     update:
       "x-codeSamples":
@@ -553,6 +390,263 @@ actions:
             async function run() {
               const result = await dub.create({
                 url: "https://google/com",
+              });
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/country"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getCountryAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.countries({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/city"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getCityAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.cities({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/workspaces"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getWorkspaces"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.list();
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/clicks"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getClicksAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.clicks({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/timeseries"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getTimeseriesAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.timeseries({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/top_links"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getTopLinks"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.topLinks({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/tags"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "createTag"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.create({
+                tag: "<value>",
+              });
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/domains/{slug}/primary"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "setPrimaryDomain"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.setPrimary("acme.com");
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/links/count"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getLinksCount"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.count({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/links/{linkId}"]["delete"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "deleteLink"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.delete("<value>");
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/analytics/device"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "getDeviceAnalytics"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.devices({});
+
+              // Handle the result
+              console.log(result)
+            }
+
+            run();
+  - target: $["paths"]["/workspaces"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "typescript"
+          "label": "createWorkspace"
+          "source": |-
+            import { Dub } from "dub";
+
+            const dub = new Dub({
+              token: "DUB_API_KEY",
+              workspaceId: "<value>",
+            });
+
+            async function run() {
+              const result = await dub.create({
+                name: "<value>",
+                slug: "<value>",
               });
 
               // Handle the result

--- a/docs/sdks/domains/README.md
+++ b/docs/sdks/domains/README.md
@@ -129,9 +129,7 @@ const dub = new Dub({
 });
 
 async function run() {
-  const slug = "acme.com";
-  
-  const result = await dub.domains.delete(slug);
+  const result = await dub.domains.delete("acme.com");
 
   // Handle the result
   console.log(result)
@@ -182,10 +180,7 @@ const dub = new Dub({
 });
 
 async function run() {
-  const slug = "acme.com";
-  const requestBody = {};
-  
-  const result = await dub.domains.update(slug, requestBody);
+  const result = await dub.domains.update("acme.com", {});
 
   // Handle the result
   console.log(result)
@@ -237,9 +232,7 @@ const dub = new Dub({
 });
 
 async function run() {
-  const slug = "acme.com";
-  
-  const result = await dub.domains.setPrimary(slug);
+  const result = await dub.domains.setPrimary("acme.com");
 
   // Handle the result
   console.log(result)
@@ -290,12 +283,9 @@ const dub = new Dub({
 });
 
 async function run() {
-  const slug = "acme.com";
-  const requestBody = {
+  const result = await dub.domains.transfer("acme.com", {
     newWorkspaceId: "<value>",
-  };
-  
-  const result = await dub.domains.transfer(slug, requestBody);
+  });
 
   // Handle the result
   console.log(result)

--- a/docs/sdks/links/README.md
+++ b/docs/sdks/links/README.md
@@ -232,9 +232,7 @@ const dub = new Dub({
 });
 
 async function run() {
-  const linkId = "<value>";
-  
-  const result = await dub.links.delete(linkId);
+  const result = await dub.links.delete("<value>");
 
   // Handle the result
   console.log(result)
@@ -285,12 +283,9 @@ const dub = new Dub({
 });
 
 async function run() {
-  const linkId = "<value>";
-  const requestBody = {
+  const result = await dub.links.update("<value>", {
     url: "https://google/com",
-  };
-  
-  const result = await dub.links.update(linkId, requestBody);
+  });
 
   // Handle the result
   console.log(result)

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "dub",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dub",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dub",
-      "version": "0.26.1",
+      "version": "0.27.0",
       "devDependencies": {
         "@types/jsonpath": "^0.2.4",
         "@types/node": "^20.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dub",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "author": "Dub",  
   "main": "./index.js",
   "sideEffects": false,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,7 +64,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
     language: "typescript",
     openapiDocVersion: "0.0.1",
-    sdkVersion: "0.26.1",
-    genVersion: "2.322.5",
-    userAgent: "speakeasy-sdk/typescript 0.26.1 2.322.5 0.0.1 dub",
+    sdkVersion: "0.27.0",
+    genVersion: "2.326.0",
+    userAgent: "speakeasy-sdk/typescript 0.27.0 2.326.0 0.0.1 dub",
 } as const;

--- a/src/sdk/analytics.ts
+++ b/src/sdk/analytics.ts
@@ -46,15 +46,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the number of clicks for a link, a domain, or the authenticated workspace.
      */
     async clicks(
-        input: operations.GetClicksAnalyticsRequest,
+        request?: operations.GetClicksAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<number> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetClicksAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -136,7 +137,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -149,12 +150,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -302,15 +303,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the number of clicks for a link, a domain, or the authenticated workspace over a period of time.
      */
     async timeseries(
-        input: operations.GetTimeseriesAnalyticsRequest,
+        request?: operations.GetTimeseriesAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.ResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetTimeseriesAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -392,7 +394,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -405,12 +407,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -558,15 +560,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top countries by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async countries(
-        input: operations.GetCountryAnalyticsRequest,
+        request?: operations.GetCountryAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetCountryAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetCountryAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -648,7 +651,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -661,12 +664,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -816,15 +819,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top countries by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async cities(
-        input: operations.GetCityAnalyticsRequest,
+        request?: operations.GetCityAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetCityAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetCityAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -906,7 +910,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -919,12 +923,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1074,15 +1078,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top devices by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async devices(
-        input: operations.GetDeviceAnalyticsRequest,
+        request?: operations.GetDeviceAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetDeviceAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetDeviceAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -1164,7 +1169,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1177,12 +1182,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1332,15 +1337,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top browsers by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async browsers(
-        input: operations.GetBrowserAnalyticsRequest,
+        request?: operations.GetBrowserAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetBrowserAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetBrowserAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -1422,7 +1428,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1435,12 +1441,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1590,15 +1596,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top OS by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async os(
-        input: operations.GetOSAnalyticsRequest,
+        request?: operations.GetOSAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetOSAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetOSAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -1680,7 +1687,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1693,12 +1700,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1848,15 +1855,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top referers by number of clicks for a link, a domain, or the authenticated workspace.
      */
     async referers(
-        input: operations.GetRefererAnalyticsRequest,
+        request?: operations.GetRefererAnalyticsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetRefererAnalyticsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetRefererAnalyticsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -1938,7 +1946,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1951,12 +1959,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -2106,15 +2114,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top links by number of clicks for a domain or the authenticated workspace.
      */
     async topLinks(
-        input: operations.GetTopLinksRequest,
+        request?: operations.GetTopLinksRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetTopLinksResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetTopLinksRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -2196,7 +2205,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -2209,12 +2218,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -2362,15 +2371,16 @@ export class Analytics extends ClientSDK {
      * Retrieve the top URLs by number of clicks for a given short link.
      */
     async topUrls(
-        input: operations.GetTopURLsRequest,
+        request?: operations.GetTopURLsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<operations.GetTopURLsResponseBody>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetTopURLsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -2452,7 +2462,7 @@ export class Analytics extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -2465,12 +2475,12 @@ export class Analytics extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 

--- a/src/sdk/domains.ts
+++ b/src/sdk/domains.ts
@@ -47,9 +47,11 @@ export class Domains extends ClientSDK {
      * Retrieve a list of domains associated with the authenticated workspace.
      */
     async list(
-        _input: operations.ListDomainsRequest,
+        request?: operations.ListDomainsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<components.DomainSchema>> {
+        const input$ = typeof request === "undefined" ? {} : request;
+        void input$; // request input is unused
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
@@ -100,7 +102,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -112,12 +114,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -265,16 +267,17 @@ export class Domains extends ClientSDK {
      * Add a domain to the authenticated workspace.
      */
     async add(
-        input: operations.AddDomainRequestBody | undefined,
+        request?: operations.AddDomainRequestBody | undefined,
         options?: RequestOptions
     ): Promise<components.DomainSchema> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Content-Type", "application/json");
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.AddDomainRequestBody$.outboundSchema.optional().parse(value$),
             "Input validation failed"
         );
@@ -327,7 +330,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -340,12 +343,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -562,7 +565,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -575,12 +578,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -800,7 +803,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -813,12 +816,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1032,7 +1035,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1045,12 +1048,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1270,7 +1273,7 @@ export class Domains extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1283,12 +1286,12 @@ export class Domains extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 

--- a/src/sdk/links.ts
+++ b/src/sdk/links.ts
@@ -47,15 +47,16 @@ export class Links extends ClientSDK {
      * Retrieve a list of links for the authenticated workspace. The list will be paginated and the provided query parameters allow filtering the returned links.
      */
     async list(
-        input: operations.GetLinksRequest,
+        request?: operations.GetLinksRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<components.LinkSchema>> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetLinksRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -126,7 +127,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -139,12 +140,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -292,16 +293,17 @@ export class Links extends ClientSDK {
      * Create a new link for the authenticated workspace.
      */
     async create(
-        input: operations.CreateLinkRequestBody | undefined,
+        request?: operations.CreateLinkRequestBody | undefined,
         options?: RequestOptions
     ): Promise<components.LinkSchema> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Content-Type", "application/json");
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.CreateLinkRequestBody$.outboundSchema.optional().parse(value$),
             "Input validation failed"
         );
@@ -354,7 +356,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -367,12 +369,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -519,13 +521,17 @@ export class Links extends ClientSDK {
      * @remarks
      * Retrieve the number of links for the authenticated workspace. The provided query parameters allow filtering the returned links.
      */
-    async count(input: operations.GetLinksCountRequest, options?: RequestOptions): Promise<number> {
+    async count(
+        request?: operations.GetLinksCountRequest | undefined,
+        options?: RequestOptions
+    ): Promise<number> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetLinksCountRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -598,7 +604,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -611,12 +617,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -764,15 +770,16 @@ export class Links extends ClientSDK {
      * Retrieve the info for a link.
      */
     async get(
-        input: operations.GetLinkInfoRequest,
+        request?: operations.GetLinkInfoRequest | undefined,
         options?: RequestOptions
     ): Promise<components.LinkSchema> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetLinkInfoRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -831,7 +838,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -844,12 +851,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1066,7 +1073,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1079,12 +1086,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1304,7 +1311,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1317,12 +1324,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -1470,16 +1477,17 @@ export class Links extends ClientSDK {
      * Bulk create up to 100 links for the authenticated workspace.
      */
     async createMany(
-        input: Array<operations.RequestBody> | undefined,
+        request?: Array<operations.RequestBody> | undefined,
         options?: RequestOptions
     ): Promise<Array<components.LinkSchema>> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Content-Type", "application/json");
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => z.array(operations.RequestBody$.outboundSchema).optional().parse(value$),
             "Input validation failed"
         );
@@ -1532,7 +1540,7 @@ export class Links extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -1545,12 +1553,12 @@ export class Links extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 

--- a/src/sdk/metatags.ts
+++ b/src/sdk/metatags.ts
@@ -45,15 +45,16 @@ export class Metatags extends ClientSDK {
      * Retrieve the metatags for a URL.
      */
     async get(
-        input: operations.GetMetatagsRequest,
+        request: operations.GetMetatagsRequest,
         options?: RequestOptions
     ): Promise<operations.GetMetatagsResponseBody> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetMetatagsRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -83,7 +84,7 @@ export class Metatags extends ClientSDK {
         const securitySettings$ = this.resolveGlobalSecurity(security$);
 
         const doOptions = { context, errorCodes: ["4XX", "5XX"] };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -96,7 +97,7 @@ export class Metatags extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         if (this.matchResponse(response, 200, "application/json")) {
             const responseBody = await response.json();

--- a/src/sdk/qrcodes.ts
+++ b/src/sdk/qrcodes.ts
@@ -45,13 +45,17 @@ export class QRCodes extends ClientSDK {
      * @remarks
      * Retrieve a QR code for a link.
      */
-    async get(input: operations.GetQRCodeRequest, options?: RequestOptions): Promise<string> {
+    async get(
+        request?: operations.GetQRCodeRequest | undefined,
+        options?: RequestOptions
+    ): Promise<string> {
+        const input$ = typeof request === "undefined" ? {} : request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "image/png");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetQRCodeRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -110,7 +114,7 @@ export class QRCodes extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -123,12 +127,12 @@ export class QRCodes extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 

--- a/src/sdk/tags.ts
+++ b/src/sdk/tags.ts
@@ -47,9 +47,11 @@ export class Tags extends ClientSDK {
      * Retrieve a list of tags for the authenticated workspace.
      */
     async list(
-        _input: operations.GetTagsRequest,
+        request?: operations.GetTagsRequest | undefined,
         options?: RequestOptions
     ): Promise<Array<components.TagSchema>> {
+        const input$ = typeof request === "undefined" ? {} : request;
+        void input$; // request input is unused
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
@@ -100,7 +102,7 @@ export class Tags extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -112,12 +114,12 @@ export class Tags extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -265,16 +267,17 @@ export class Tags extends ClientSDK {
      * Create a new tag for the authenticated workspace.
      */
     async create(
-        input: operations.CreateTagRequestBody | undefined,
+        request?: operations.CreateTagRequestBody | undefined,
         options?: RequestOptions
     ): Promise<components.TagSchema> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Content-Type", "application/json");
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.CreateTagRequestBody$.outboundSchema.optional().parse(value$),
             "Input validation failed"
         );
@@ -327,7 +330,7 @@ export class Tags extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -340,12 +343,12 @@ export class Tags extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 

--- a/src/sdk/workspaces.ts
+++ b/src/sdk/workspaces.ts
@@ -86,7 +86,7 @@ export class Workspaces extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -98,12 +98,12 @@ export class Workspaces extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -251,16 +251,17 @@ export class Workspaces extends ClientSDK {
      * Create a new workspace for the authenticated user.
      */
     async create(
-        input: operations.CreateWorkspaceRequestBody | undefined,
+        request?: operations.CreateWorkspaceRequestBody | undefined,
         options?: RequestOptions
     ): Promise<components.WorkspaceSchema> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Content-Type", "application/json");
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) =>
                 operations.CreateWorkspaceRequestBody$.outboundSchema.optional().parse(value$),
             "Input validation failed"
@@ -303,7 +304,7 @@ export class Workspaces extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -316,12 +317,12 @@ export class Workspaces extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 
@@ -469,15 +470,16 @@ export class Workspaces extends ClientSDK {
      * Retrieve a workspace for the authenticated user.
      */
     async get(
-        input: operations.GetWorkspaceRequest,
+        request: operations.GetWorkspaceRequest,
         options?: RequestOptions
     ): Promise<components.WorkspaceSchema> {
+        const input$ = request;
         const headers$ = new Headers();
         headers$.set("user-agent", SDK_METADATA.userAgent);
         headers$.set("Accept", "application/json");
 
         const payload$ = schemas$.parse(
-            input,
+            input$,
             (value$) => operations.GetWorkspaceRequest$.outboundSchema.parse(value$),
             "Input validation failed"
         );
@@ -524,7 +526,7 @@ export class Workspaces extends ClientSDK {
                 "5XX",
             ],
         };
-        const request = this.createRequest$(
+        const request$ = this.createRequest$(
             context,
             {
                 security: securitySettings$,
@@ -537,12 +539,12 @@ export class Workspaces extends ClientSDK {
             options
         );
 
-        const response = await this.do$(request, doOptions);
+        const response = await this.do$(request$, doOptions);
 
         const responseFields$ = {
             HttpMeta: {
                 Response: response,
-                Request: request,
+                Request: request$,
             },
         };
 


### PR DESCRIPTION
This change enables a flag that will cause the generator to infer when request and security arguments of SDK methods should be treated as optional. The rule is: if all fields of a request or security type are optional then an argument of that type will be marked as optional in methods.